### PR TITLE
Sync gateway compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Configuration for the plugin is specified as part of the Elasticsearch config fi
 - **couchbase.wrapCounters** - Enabling this flag will cause the plugin to wrap integer values from Couchbase, which are not valid JSON documents, in a simple document before indexing them in Elasticsearch. The resulting document is in the format `{ "value" : <value> }` and is stored under the ID of the original value from Couchbase.
 - **couchbase.ignoreDotIndexes** - Enabled by default (`true`). Causes the plugin to completely ignore indexes/aliases whose name starts with ".", such as ".kibana", ".marvel", etc.
 - **couchbase.includeIndexes** - Specifying one or more index/alias names (as a comma or semicolon delimited string) here will cause the plugin to ignore the existence of all other indexes. For example, if you have only a few indexes replicated from Couchbase, there's no reason to store checkpoint metadata in all other indexes. Note that this setting takes precedence over ignoreDotIndexes, so if you whitelist an index or alias that starts with a dot, the plugin will use it. 
+- **couchbase.excludeDocWrapperIndexes** - Specifying one or more index/alias names (as a comma or semicolon delimited string) here will prevent that indexes documents from being wrapped in a "doc" property. Be aware that the metadata will now be stored directly in the document so any existing "meta" property will be overwritten.
 
 ### Mapping Couchbase documents to Elasticsearch types ###
 

--- a/src/main/java/org/elasticsearch/transport/couchbase/capi/CouchbaseCAPITransportImpl.java
+++ b/src/main/java/org/elasticsearch/transport/couchbase/capi/CouchbaseCAPITransportImpl.java
@@ -127,6 +127,8 @@ public class CouchbaseCAPITransportImpl extends AbstractLifecycleComponent<Couch
         pluginSettings.setIgnoreDotIndexes(settings.getAsBoolean("couchbase.ignoreDotIndexes", true));
         pluginSettings.setIncludeIndexes(new ArrayList<String>(Arrays.asList(settings.get("couchbase.includeIndexes", "").split("[:,;\\s]"))));
         pluginSettings.getIncludeIndexes().removeAll(Arrays.asList("", null));
+        pluginSettings.setExcludeDocWrapperIndexes(new ArrayList<String>(Arrays.asList(settings.get("couchbase.excludeDocWrapperIndexes", "").split("[:,;\\s]"))));
+        pluginSettings.getExcludeDocWrapperIndexes().removeAll(Arrays.asList("", null));
 
         TypeSelector typeSelector;
         Class<? extends TypeSelector> typeSelectorClass = this.getAsClass(settings.get("couchbase.typeSelector"), DefaultTypeSelector.class);

--- a/src/main/java/org/elasticsearch/transport/couchbase/capi/ElasticSearchCAPIBehavior.java
+++ b/src/main/java/org/elasticsearch/transport/couchbase/capi/ElasticSearchCAPIBehavior.java
@@ -390,7 +390,15 @@ public class ElasticSearchCAPIBehavior implements CAPIBehavior {
                 routingField = pluginSettings.getDocumentTypeRoutingFields().get(type);
                 logger.trace("Using {} as the routing field for document type {}", routingField, type);
             }
-            boolean deleted = meta.containsKey("deleted") ? (Boolean)meta.get("deleted") : false;
+
+            boolean deleted = false;
+            if (meta.containsKey("deleted")) {
+                deleted = (Boolean)meta.get("deleted");
+            }
+            // Check for Sync Gateway _deleted flag if the document isn't already marked for deletion.
+            if (!deleted && toBeIndexed.containsKey("_deleted")) {
+                deleted = (Boolean)toBeIndexed.get("_deleted");   
+            }
             
             if(deleted) {
             	if (!ignoreDelete) {

--- a/src/main/java/org/elasticsearch/transport/couchbase/capi/ElasticSearchCAPIBehavior.java
+++ b/src/main/java/org/elasticsearch/transport/couchbase/capi/ElasticSearchCAPIBehavior.java
@@ -364,8 +364,15 @@ public class ElasticSearchCAPIBehavior implements CAPIBehavior {
             // and the document contents to be indexed are in json
 
             Map<String, Object> toBeIndexed = new HashMap<String, Object>();
+
+            // If there is no doc wrapper for this index then the document will not be stored under a "doc" property.
+            if(pluginSettings.getExcludeDocWrapperIndexes() != null && pluginSettings.getExcludeDocWrapperIndexes().contains(index)) {
+                toBeIndexed = json;
+            } else {
+                toBeIndexed.put("doc", json);
+            }
+
             toBeIndexed.put("meta", meta);
-            toBeIndexed.put("doc", json);
 
             revisions.put(id, rev);
 
@@ -550,6 +557,10 @@ public class ElasticSearchCAPIBehavior implements CAPIBehavior {
         GetResponse response = client.prepareGet(index, docType, docId).execute().actionGet();
         if(response != null && response.isExists()) {
             Map<String,Object> esDocument = response.getSourceAsMap();
+            // If there is no doc wrapper for this index then return the whole document
+            if(pluginSettings.getExcludeDocWrapperIndexes() != null && pluginSettings.getExcludeDocWrapperIndexes().contains(index)) {
+                return esDocument;
+            }
             return (Map<String, Object>)esDocument.get("doc");
         }
         return null;

--- a/src/main/java/org/elasticsearch/transport/couchbase/capi/PluginSettings.java
+++ b/src/main/java/org/elasticsearch/transport/couchbase/capi/PluginSettings.java
@@ -33,6 +33,8 @@ public class PluginSettings {
 
     private List<String> includeIndexes;
 
+    private List<String> excludeDocWrapperIndexes;
+
     public PluginSettings() {
         this.setCheckpointDocumentType(DEFAULT_DOCUMENT_TYPE_CHECKPOINT);
         this.setResolveConflicts(true);
@@ -48,9 +50,10 @@ public class PluginSettings {
         this.documentTypeRoutingFields = null;
         this.ignoreDeletes = null;
         this.ignoreDotIndexes = true;
+        this.excludeDocWrapperIndexes = null;
     }
 
-    public PluginSettings(String checkpointDocumentType, Boolean resolveConflicts, Boolean wrapCounters, Boolean ignoreFailures, String dynamicTypePath, long maxConcurrentRequests, long bulkIndexRetries, long bulkIndexRetryWaitMs, TypeSelector typeSelector, ParentSelector parentSelector, KeyFilter keyFilter, Map<String, String> documentTypeRoutingFields, List<String> ignoreDeletes, Boolean ignoreDotIndexes, List<String> includeIndexes) {
+    public PluginSettings(String checkpointDocumentType, Boolean resolveConflicts, Boolean wrapCounters, Boolean ignoreFailures, String dynamicTypePath, long maxConcurrentRequests, long bulkIndexRetries, long bulkIndexRetryWaitMs, TypeSelector typeSelector, ParentSelector parentSelector, KeyFilter keyFilter, Map<String, String> documentTypeRoutingFields, List<String> ignoreDeletes, Boolean ignoreDotIndexes, List<String> includeIndexes, List<String> excludeDocWrapperIndexes) {
         this.includeIndexes = includeIndexes;
         this.setCheckpointDocumentType(checkpointDocumentType);
         this.setResolveConflicts(resolveConflicts);
@@ -66,6 +69,7 @@ public class PluginSettings {
         this.documentTypeRoutingFields = documentTypeRoutingFields;
         this.ignoreDeletes = ignoreDeletes;
         this.ignoreDotIndexes = ignoreDotIndexes;
+        this.excludeDocWrapperIndexes = excludeDocWrapperIndexes;
     }
 
     @Override
@@ -86,6 +90,7 @@ public class PluginSettings {
                 ", documentTypeRoutingFields=" + documentTypeRoutingFields +
                 ", ignoreDeletes=" + ignoreDeletes +
                 ", includeIndexes=" + includeIndexes +
+                ", excludeDocWrapperIndexes=" + excludeDocWrapperIndexes +
                 '}';
     }
 
@@ -207,5 +212,13 @@ public class PluginSettings {
 
     public void setIncludeIndexes(List<String> includeIndexes) {
         this.includeIndexes = includeIndexes;
+    }
+
+    public List<String> getExcludeDocWrapperIndexes() {
+        return excludeDocWrapperIndexes;
+    }
+
+    public void setExcludeDocWrapperIndexes(List<String> excludeDocWrapperIndexes) {
+        this.excludeDocWrapperIndexes = excludeDocWrapperIndexes;
     }
 }


### PR DESCRIPTION
Changes:
- A new excludeDocWrapperIndexes option has been provided to allow the doc wrapper to be removed on certain indexes.
- The Sync Gateway tombstone documents will not be indexed.
