### PR TITLE
Update versions for Elasticsearch 2.3.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,9 +2,9 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.couchbase</groupId>
   <artifactId>elasticsearch-transport-couchbase</artifactId>
-  <version>2.2.3.1</version>
+  <version>2.2.3.3</version>
     <properties>
-        <elasticsearch.version>2.3.1</elasticsearch.version>
+        <elasticsearch.version>2.3.3</elasticsearch.version>
     </properties>
 
     <repositories>
@@ -38,7 +38,7 @@
         <dependency>
         	<groupId>com.couchbase</groupId>
         	<artifactId>couchbase-capi-server</artifactId>
-            <version>1.3.0</version>
+            <version>1.4.0</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>


### PR DESCRIPTION
- Update POM with new versions to support ES 2.3.3
- Update couchbase-capi-server dep to 1.4.0 version
