### PR TITLE
Build for 2.2.4.4 - Upgrade ES to 2.4.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>21.0</version>
+            <version>20.0</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -2,9 +2,9 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.couchbase</groupId>
   <artifactId>elasticsearch-transport-couchbase</artifactId>
-  <version>2.2.3.3</version>
+  <version>2.2.4.4</version>
     <properties>
-        <elasticsearch.version>2.3.3</elasticsearch.version>
+        <elasticsearch.version>2.4.4</elasticsearch.version>
     </properties>
 
     <repositories>
@@ -38,12 +38,12 @@
         <dependency>
         	<groupId>com.couchbase</groupId>
         	<artifactId>couchbase-capi-server</artifactId>
-            <version>1.4.0</version>
+            <version>1.4.1</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>18.0</version>
+            <version>21.0</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/src/main/plugin-metadata/plugin-descriptor.properties
+++ b/src/main/plugin-metadata/plugin-descriptor.properties
@@ -65,7 +65,7 @@ java.version=1.7
 # elasticsearch release. This version is checked when the plugin
 # is loaded so Elasticsearch will refuse to start in the presence of
 # plugins with the incorrect elasticsearch.version.
-elasticsearch.version=2.4
+elasticsearch.version=2.4.4
 #
 ### deprecated elements for jvm plugins :
 #

--- a/src/main/plugin-metadata/plugin-descriptor.properties
+++ b/src/main/plugin-metadata/plugin-descriptor.properties
@@ -34,7 +34,7 @@
 description=Couchbase to Elasticsearch Transport
 #
 # 'version': plugin's version
-version=2.2.3.3
+version=2.2.4.4
 #
 # 'name': the plugin name
 name=transport-couchbase
@@ -65,7 +65,7 @@ java.version=1.7
 # elasticsearch release. This version is checked when the plugin
 # is loaded so Elasticsearch will refuse to start in the presence of
 # plugins with the incorrect elasticsearch.version.
-elasticsearch.version=2.3.3
+elasticsearch.version=2.4
 #
 ### deprecated elements for jvm plugins :
 #


### PR DESCRIPTION
* Upgrade CAPI library to 1.4.1 (was used for 2.4.1 plugin as well, netty library version changes)
* Upgrade guava library to 21.0
* Upgrade pom & plugin for Elasticsearch 2.4.4